### PR TITLE
Use correct flux secret name

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ deploy-keys:
 		  - identity
 		  - identity.pub
 		  - known_hosts
-		  name: flux-credentials
+		  name: flux-system
 		  namespace: flux-system
 		generatorOptions:
 		  disableNameSuffixHash: true


### PR DESCRIPTION
Flux doesn't like `flux-credentials` anymore I guess.