### PR TITLE
pass array to secretRef

### DIFF
--- a/api/kubernetes/deployment.yaml
+++ b/api/kubernetes/deployment.yaml
@@ -20,8 +20,8 @@ spec:
       - name: api
         image: northamerica-northeast1-docker.pkg.dev/phsx-sp-sdi-livebrant/safeinputs/api:main-e9f5369-1667937341 # {"$imagepolicy": "flux-system:api"}
         envFrom:
-          secretRef:
-            name: nats-jwt-secret
+          - secretRef:
+              name: nats-jwt-secret
         securityContext:
           # No new privs for process or it's children
           # https://github.com/kubernetes/design-proposals-archive/blob/main/auth/no-new-privs.md


### PR DESCRIPTION
This commit fixes the `Deployment/api/api validation error: cannot restore slice from map` error we were seeing in the flux logs by [passing the secretRef as an array](https://opensource.com/article/19/6/introduction-kubernetes-secrets-and-configmaps#:~:text=envFrom%3A%0A%0A%2D%20secretRef%3A%0A%0A%C2%A0%20%C2%A0%20name%3A%20mariadb%2Duser%2Dcreds).