### PR TITLE
Mock react-i18next to fix warning

### DIFF
--- a/ui/src/setupTests.js
+++ b/ui/src/setupTests.js
@@ -3,3 +3,12 @@
 // expect(element).toHaveTextContent(/react/i)
 // learn more: https://github.com/testing-library/jest-dom
 import '@testing-library/jest-dom'
+
+jest.mock('react-i18next', () => ({
+  // this mock makes sure any components using the translate hook can use it without a warning being shown
+  useTranslation: () => {
+    return {
+      t: (str: string): string => str,
+    }
+  },
+}))


### PR DESCRIPTION
This commit mocks the react-i18next library to resolve the warning that appears when we run the tests:

```js
  console.warn
    react-i18next:: You will need to pass in an i18next instance by using initReactI18next

      137 |     undefined
      138 |
    > 139 |   const { t } = useTranslation()
          |                 ^
      140 |
      141 |   //
      142 |   // Function for the API call -> useMutation
```

A solution (the one I went with) is to mock the `t` function to return whatever is passed, so that translations don't need to be loaded in tests. This mock is applied once per test file using the `setupTests.js` file that jest's config option [setupfilesafterenv](https://jestjs.io/docs/configuration#setupfilesafterenv-array) is pointing to.