### PR TITLE
Added jetstream to api (#86)

### DIFF
--- a/.devcontainer/ui/devcontainer.json
+++ b/.devcontainer/ui/devcontainer.json
@@ -1,0 +1,31 @@
+{
+  "name": "SafeInputs UI Development Container",
+  "image": "mcr.microsoft.com/devcontainers/javascript-node:16-bullseye",
+  "features": {
+    "ghcr.io/devcontainers/features/node:1": {},
+    "ghcr.io/devcontainers-contrib/features/jest:1": {}
+  },
+  "customizations": {
+		// Configure properties specific to VS Code.
+		"vscode": {
+			"settings": {},			
+      "extensions": [
+        "yzhang.markdown-all-in-one", 
+        "ohsen1.prettify-json",
+        "wallabyjs.console-ninja",
+        "oderwat.indent-rainbow",
+        "dbaeumer.vscode-eslint",
+        "esbenp.prettier-vscode",
+        "rvest.vs-code-prettier-eslint",
+        "mutantdino.resourcemonitor"
+      ]
+		}
+	},
+  "portsAttributes": {
+		"3000": {
+			"label": "Safe-Inputs UI",
+			"onAutoForward": "notify"
+		}
+	},
+
+}

--- a/api/kubernetes/deployment.yaml
+++ b/api/kubernetes/deployment.yaml
@@ -18,7 +18,7 @@ spec:
     spec:
       containers:
       - name: api
-        image: northamerica-northeast1-docker.pkg.dev/phsx-sp-sdi-livebrant/safeinputs/api:main-755fc7d-1669316921 # {"$imagepolicy": "flux-system:api"}
+        image: northamerica-northeast1-docker.pkg.dev/phsx-sp-sdi-livebrant/safeinputs/api:main-5e53bf1-1671214565 # {"$imagepolicy": "flux-system:api"}
         envFrom:
         - secretRef:
             name: nats-jwt-secret

--- a/ui/kubernetes/deployment.yaml
+++ b/ui/kubernetes/deployment.yaml
@@ -25,7 +25,7 @@ spec:
         runAsNonRoot: true
       containers:
       - name: ui
-        image: northamerica-northeast1-docker.pkg.dev/phsx-sp-sdi-livebrant/safeinputs/ui:main-72befdf-1670606266 # {"$imagepolicy": "flux-system:ui"}
+        image: northamerica-northeast1-docker.pkg.dev/phsx-sp-sdi-livebrant/safeinputs/ui:main-8d092aa-1671050532 # {"$imagepolicy": "flux-system:ui"}
         # Container specific security settings:
         securityContext:
           # No new privs for process or it's children


### PR DESCRIPTION
* added jetstream to api (#84)

added jetstream

* [ci skip] northamerica-northeast1-docker.pkg.dev/phsx-sp-sdi-livebrant/safeinputs/api:main-fb5c2ba-1670961107

* changed back to core nats

* [ci skip] northamerica-northeast1-docker.pkg.dev/phsx-sp-sdi-livebrant/safeinputs/api:main-9b6c339-1670966934

* Adding of dev container to main repo. (#85)

* Create devcontainer.json

* Update devcontainer.json

* updated to show CPU

* updated container

* removed workspace setting

* test

* [ci skip] northamerica-northeast1-docker.pkg.dev/phsx-sp-sdi-livebrant/safeinputs/ui:main-e295bc2-1671046176

* Update index.tsx

* [ci skip] northamerica-northeast1-docker.pkg.dev/phsx-sp-sdi-livebrant/safeinputs/ui:main-8d092aa-1671050532

* [ci skip] northamerica-northeast1-docker.pkg.dev/phsx-sp-sdi-livebrant/safeinputs/api:main-5e53bf1-1671214565

Co-authored-by: fluxbot <fluxcd@users.noreply.github.com>
Co-authored-by: John Bain <john.bain@gmail.com>
Co-authored-by: Geordin Raganold <91495472+GRaganold@users.noreply.github.com>