### PR TITLE
Enable test coverage reporting for the UI

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -30,7 +30,7 @@
   "scripts": {
     "start": "react-scripts start",
     "build": "react-scripts build",
-    "test": "react-scripts test --watchAll=false",
+    "test": "react-scripts test --watchAll=false --coverage",
     "eject": "react-scripts eject"
   },
   "eslintConfig": {


### PR DESCRIPTION
Jest (the testing framework used by default with Create React App) has an option to report on how many lines of code are covered by tests. This commit enables that option.