### PR TITLE
Fix typo in UI's `cloudbuild.yaml`

### DIFF
--- a/ui/cloudbuild.yaml
+++ b/ui/cloudbuild.yaml
@@ -18,7 +18,7 @@ steps:
     args:
       - '-c'
       - |
-        echo "northamerica-northeast1-docker.pkg.dev/${PROJECT_ID}s/safeinputs/ui:$BRANCH_NAME-$SHORT_SHA-$(date +%s)" > /workspace/imagename
+        echo "northamerica-northeast1-docker.pkg.dev/${PROJECT_ID}/safeinputs/ui:$BRANCH_NAME-$SHORT_SHA-$(date +%s)" > /workspace/imagename
 
   - name: 'gcr.io/cloud-builders/docker'
     id: build-if-main


### PR DESCRIPTION
Remove additional `s` in the image path in UI directory's Cloud Build configuration.