### PR TITLE
Reduce auth nav button spinner flashes

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -24,6 +24,7 @@
         "react-hook-form": "^7.51.5",
         "react-icons": "^4.7.1",
         "react-router-dom": "^6.7.0",
+        "spin-delay": "^2.0.0",
         "xlsx": "^0.18.5",
         "yup": "^1.2.0"
       },
@@ -16055,6 +16056,15 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
       "dev": true
+    },
+    "node_modules/spin-delay": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/spin-delay/-/spin-delay-2.0.0.tgz",
+      "integrity": "sha512-uNQnIjJ3Ms5ojVUMJaUZrF2Gs2gsSrVExueYrh8/yGg+ecPj65aZ0QI6ln7dguw9Wpp+bVCqGeY2Q9bT4MCL/A==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=17.0.1"
+      }
     },
     "node_modules/split": {
       "version": "1.0.1",

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -56,6 +56,7 @@
         "react-test-renderer": "^18.2.0",
         "swc-loader": "^0.2.3",
         "ts-jest": "^29.1.1",
+        "type-fest": "^4.20.1",
         "typescript": "^5.0.4"
       }
     },
@@ -6579,6 +6580,18 @@
       },
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ansi-escapes/node_modules/type-fest": {
+      "version": "0.21.3",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
+      "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=10"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -16806,10 +16819,13 @@
       }
     },
     "node_modules/type-fest": {
-      "version": "0.21.3",
+      "version": "4.20.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.20.1.tgz",
+      "integrity": "sha512-R6wDsVsoS9xYOpy8vgeBlqpdOyzJ12HNfQhC/aAKWM3YoCV9TtunJzh/QpkMgeDhkoynDcw5f1y+qF9yc/HHyg==",
+      "dev": true,
       "license": "(MIT OR CC0-1.0)",
       "engines": {
-        "node": ">=10"
+        "node": ">=16"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"

--- a/ui/package.json
+++ b/ui/package.json
@@ -32,6 +32,7 @@
     "react-hook-form": "^7.51.5",
     "react-icons": "^4.7.1",
     "react-router-dom": "^6.7.0",
+    "spin-delay": "^2.0.0",
     "xlsx": "^0.18.5",
     "yup": "^1.2.0"
   },

--- a/ui/package.json
+++ b/ui/package.json
@@ -64,6 +64,7 @@
     "react-test-renderer": "^18.2.0",
     "swc-loader": "^0.2.3",
     "ts-jest": "^29.1.1",
+    "type-fest": "^4.20.1",
     "typescript": "^5.0.4"
   }
 }

--- a/ui/src/components/Link.tsx
+++ b/ui/src/components/Link.tsx
@@ -1,0 +1,29 @@
+import type { LinkProps as ChakraLinkProps } from '@chakra-ui/react';
+import { Link as ChakraLink } from '@chakra-ui/react';
+
+import type { LinkProps as ReactRouterLinkProps } from 'react-router-dom';
+import { Link as ReactRouterLink } from 'react-router-dom';
+
+import type { SetRequired } from 'type-fest';
+
+type InAppLinkProps = Omit<
+  ChakraLinkProps & ReactRouterLinkProps,
+  'isExternal' | 'href' | 'as'
+>;
+
+type ExternalLinkProps = Omit<
+  SetRequired<ChakraLinkProps, 'href'>,
+  'isExternal'
+>;
+
+function Link(props: ExternalLinkProps): JSX.Element;
+function Link(props: InAppLinkProps): JSX.Element;
+function Link(props: ExternalLinkProps | InAppLinkProps): JSX.Element {
+  return 'href' in props ? (
+    <ChakraLink {...props} isExternal={true} />
+  ) : (
+    <ChakraLink {...props} as={ReactRouterLink} />
+  );
+}
+
+export { Link };

--- a/ui/src/components/RouterLink.tsx
+++ b/ui/src/components/RouterLink.tsx
@@ -1,9 +1,0 @@
-import type { LinkProps as ChakraLinkLinkProps } from '@chakra-ui/react';
-import { Link as ChakraLink } from '@chakra-ui/react';
-
-import type { LinkProps as ReactRouterLinkProps } from 'react-router-dom';
-import { Link as ReactRouterLink } from 'react-router-dom';
-
-export const RouterLink = (
-  props: ChakraLinkLinkProps & ReactRouterLinkProps,
-) => <ChakraLink as={ReactRouterLink} {...props} />;

--- a/ui/src/components/RouterLink.tsx
+++ b/ui/src/components/RouterLink.tsx
@@ -1,0 +1,9 @@
+import type { LinkProps as ChakraLinkLinkProps } from '@chakra-ui/react';
+import { Link as ChakraLink } from '@chakra-ui/react';
+
+import type { LinkProps as ReactRouterLinkProps } from 'react-router-dom';
+import { Link as ReactRouterLink } from 'react-router-dom';
+
+export const RouterLink = (
+  props: ChakraLinkLinkProps & ReactRouterLinkProps,
+) => <ChakraLink as={ReactRouterLink} {...props} />;

--- a/ui/src/components/auth/AuthNavButton.tsx
+++ b/ui/src/components/auth/AuthNavButton.tsx
@@ -5,6 +5,8 @@ import { Trans, t } from '@lingui/macro';
 
 import { useLocation } from 'react-router-dom';
 
+import { RouterLink } from '../RouterLink.tsx';
+
 import { useSession } from './session.tsx';
 
 export default function AuthNavButton(StyleProps: ButtonProps): JSX.Element {
@@ -14,16 +16,18 @@ export default function AuthNavButton(StyleProps: ButtonProps): JSX.Element {
     allow_unauthenticated: true,
   });
 
+  const showLoading = status === 'syncing';
+
   if (session?.email) {
     return (
       <>
         {session?.email}
         <Button
+          as="button"
           {...StyleProps}
-          isLoading={status === 'syncing'}
+          isLoading={showLoading}
           loadingText={t`Syncing session`}
           onClick={() => signOut()}
-          as="button"
         >
           <Trans>Sign Out</Trans>
         </Button>
@@ -32,17 +36,17 @@ export default function AuthNavButton(StyleProps: ButtonProps): JSX.Element {
   } else {
     return (
       <Button
-        {...StyleProps}
-        isLoading={status === 'syncing'}
-        loadingText={t`Syncing session`}
-        href={
+        as={RouterLink}
+        to={
           pathname.startsWith('/signin')
-            ? ''
+            ? window.location
             : `/signin?${new URLSearchParams({
                 post_auth_redirect: pathname + (search || ''),
               })}`
         }
-        as="a"
+        {...StyleProps}
+        isLoading={showLoading}
+        loadingText={t`Syncing session`}
       >
         <Trans>Sign In</Trans>
       </Button>

--- a/ui/src/components/auth/AuthNavButton.tsx
+++ b/ui/src/components/auth/AuthNavButton.tsx
@@ -5,6 +5,8 @@ import { Trans, t } from '@lingui/macro';
 
 import { useLocation } from 'react-router-dom';
 
+import { useSpinDelay } from 'spin-delay';
+
 import { Link } from '../Link.tsx';
 
 import { useSession } from './session.tsx';
@@ -16,7 +18,7 @@ export default function AuthNavButton(StyleProps: ButtonProps): JSX.Element {
     allow_unauthenticated: true,
   });
 
-  const showLoading = status === 'syncing';
+  const showLoading = useSpinDelay(status === 'syncing');
 
   if (session?.email) {
     return (

--- a/ui/src/components/auth/AuthNavButton.tsx
+++ b/ui/src/components/auth/AuthNavButton.tsx
@@ -5,7 +5,7 @@ import { Trans, t } from '@lingui/macro';
 
 import { useLocation } from 'react-router-dom';
 
-import { RouterLink } from '../RouterLink.tsx';
+import { Link } from '../Link.tsx';
 
 import { useSession } from './session.tsx';
 
@@ -36,7 +36,7 @@ export default function AuthNavButton(StyleProps: ButtonProps): JSX.Element {
   } else {
     return (
       <Button
-        as={RouterLink}
+        as={Link}
         to={
           pathname.startsWith('/signin')
             ? window.location

--- a/ui/src/components/layout/Footer.tsx
+++ b/ui/src/components/layout/Footer.tsx
@@ -8,7 +8,7 @@ import {
 } from '@chakra-ui/react';
 import { Trans } from '@lingui/macro';
 
-import { Link as ReactRouterLink } from 'react-router-dom';
+import { RouterLink } from '../RouterLink.tsx';
 
 // import CanadaWhiteFont from '../../assets/wmms-blk.svg'
 
@@ -88,13 +88,9 @@ export default function Footer() {
               <SimpleGrid columns={[1, null, 2]} gap={{ base: 3, md: 0 }}>
                 <Box pt={{ base: 6, md: 20 }}>
                   <Trans>
-                    <Link
-                      as={ReactRouterLink}
-                      to="/termsAndConditions"
-                      {...LinkStyle}
-                    >
+                    <RouterLink to="/termsAndConditions" {...LinkStyle}>
                       <Text>Terms and Conditions</Text>
-                    </Link>
+                    </RouterLink>
                   </Trans>
                 </Box>
                 <Box pt={{ base: 0, md: 20 }}>

--- a/ui/src/components/layout/Footer.tsx
+++ b/ui/src/components/layout/Footer.tsx
@@ -1,14 +1,7 @@
-import {
-  Box,
-  Link,
-  Text,
-  SimpleGrid,
-  Container,
-  Spacer,
-} from '@chakra-ui/react';
+import { Box, Text, SimpleGrid, Container, Spacer } from '@chakra-ui/react';
 import { Trans } from '@lingui/macro';
 
-import { RouterLink } from '../RouterLink.tsx';
+import { Link } from '../Link.tsx';
 
 // import CanadaWhiteFont from '../../assets/wmms-blk.svg'
 
@@ -88,9 +81,9 @@ export default function Footer() {
               <SimpleGrid columns={[1, null, 2]} gap={{ base: 3, md: 0 }}>
                 <Box pt={{ base: 6, md: 20 }}>
                   <Trans>
-                    <RouterLink to="/termsAndConditions" {...LinkStyle}>
+                    <Link to="/termsAndConditions" {...LinkStyle}>
                       <Text>Terms and Conditions</Text>
-                    </RouterLink>
+                    </Link>
                   </Trans>
                 </Box>
                 <Box pt={{ base: 0, md: 20 }}>

--- a/ui/src/components/layout/Header.tsx
+++ b/ui/src/components/layout/Header.tsx
@@ -7,7 +7,7 @@ import CanadaLogoEn from '../../assets/sig-blk-en.svg';
 import CanadaLogoFr from '../../assets/sig-blk-fr.svg';
 import AuthNavButton from '../auth/AuthNavButton.tsx';
 import LanguageButton from '../LanguageButton.tsx';
-import { RouterLink } from '../RouterLink.tsx';
+import { Link } from '../Link.tsx';
 
 const NavButtonStyle = {
   h: '30px',
@@ -33,7 +33,7 @@ export default function Header() {
       <Box bg="#EEEEEE">
         <Container maxW="7xl" px={{ base: 5, md: 10 }} py={4}>
           <HStack justify="space-between">
-            <RouterLink
+            <Link
               to="/"
               bg="transparent"
               h="auto"
@@ -44,13 +44,13 @@ export default function Header() {
               minW={{ base: '180px', sm: '265px', md: '400px', lg: '365px' }}
             >
               {i18n.locale === 'en' ? <CanadaLogoEn /> : <CanadaLogoFr />}
-            </RouterLink>
+            </Link>
             <HStack spacing="2">
               <AuthNavButton {...NavButtonStyle} />
               <LanguageButton {...NavButtonStyle} />
-              <RouterLink to="/">
+              <Link to="/">
                 <Trans>Home</Trans>
-              </RouterLink>
+              </Link>
             </HStack>
           </HStack>
         </Container>

--- a/ui/src/components/layout/Header.tsx
+++ b/ui/src/components/layout/Header.tsx
@@ -1,12 +1,13 @@
-import { HStack, VStack, Box, Container, Link } from '@chakra-ui/react';
-import { Trans } from '@lingui/macro';
+import { HStack, Box, Container } from '@chakra-ui/react';
 
+import { Trans } from '@lingui/macro';
 import { useLingui } from '@lingui/react';
 
 import CanadaLogoEn from '../../assets/sig-blk-en.svg';
 import CanadaLogoFr from '../../assets/sig-blk-fr.svg';
 import AuthNavButton from '../auth/AuthNavButton.tsx';
 import LanguageButton from '../LanguageButton.tsx';
+import { RouterLink } from '../RouterLink.tsx';
 
 const NavButtonStyle = {
   h: '30px',
@@ -32,7 +33,8 @@ export default function Header() {
       <Box bg="#EEEEEE">
         <Container maxW="7xl" px={{ base: 5, md: 10 }} py={4}>
           <HStack justify="space-between">
-            <Link
+            <RouterLink
+              to="/"
               bg="transparent"
               h="auto"
               _hover={{
@@ -40,16 +42,15 @@ export default function Header() {
               }}
               maxW={{ base: '250px', sm: '300px', md: '365px', lg: '400px' }}
               minW={{ base: '180px', sm: '265px', md: '400px', lg: '365px' }}
-              href="/"
             >
               {i18n.locale === 'en' ? <CanadaLogoEn /> : <CanadaLogoFr />}
-            </Link>
+            </RouterLink>
             <HStack spacing="2">
               <AuthNavButton {...NavButtonStyle} />
               <LanguageButton {...NavButtonStyle} />
-              <Link href="/">
+              <RouterLink to="/">
                 <Trans>Home</Trans>
-              </Link>
+              </RouterLink>
             </HStack>
           </HStack>
         </Container>

--- a/ui/src/index.tsx
+++ b/ui/src/index.tsx
@@ -102,12 +102,12 @@ root.render(
             <I18nProvider i18n={i18n}>
               <Routes>
                 <Route path="/" element={<NavWrapper />}>
-                  <Route path="signin" element={<SignIn />}></Route>
-                  <Route path="" element={<ExcelParser />}></Route>
+                  <Route path="" element={<ExcelParser />} />
+                  <Route path="signin" element={<SignIn />} />
                   <Route
-                    path="/termsAndConditions"
+                    path="termsAndConditions"
                     element={<TermsAndConditions />}
-                  ></Route>
+                  />
                 </Route>
               </Routes>
             </I18nProvider>

--- a/ui/src/pages/TermsAndConditions.tsx
+++ b/ui/src/pages/TermsAndConditions.tsx
@@ -3,13 +3,14 @@ import {
   Box,
   Container,
   Divider,
-  Link,
   ListItem,
   Text,
   UnorderedList,
 } from '@chakra-ui/react';
 
 import { Trans } from '@lingui/macro';
+
+import { Link } from '../components/Link.tsx';
 
 export default function TermsAndConditions() {
   function NoticeOfAgreement() {


### PR DESCRIPTION
Two components:
  - increase consistency in use of react router links vs raw anchors (via Chakra). Header links to the homepage no longer cause a full app reload/session re-sync
   - add [spin-delay](https://www.npmjs.com/package/spin-delay) to the `AuthNavButton`, to avoid flashing short lived loading states on session syncs