### PR TITLE
Restrict relative imports to sibling/child modules in the ui directory

### DIFF
--- a/ui/.eslintrc
+++ b/ui/.eslintrc
@@ -18,6 +18,11 @@
   "settings": {
     "react": {
       "version": "18"
+    },
+    "import/resolver": {
+      "node": {
+        "moduleDirectory": ["./", "node_modules/"]
+      }
     }
   },
   "rules": {
@@ -42,7 +47,8 @@
       }
     ],
     "@typescript-eslint/consistent-type-imports": "error",
-    "react/prop-types": "off"
+    "react/prop-types": "off",
+    "no-restricted-imports": ["error", { "patterns": ["../*"] }]
   },
   "globals": {
     "window": true

--- a/ui/rspack.config.js
+++ b/ui/rspack.config.js
@@ -2,6 +2,8 @@
  * @type {import('@rspack/cli').Configuration}
  */
 
+const path = require('node:path'); // eslint-disable-line @typescript-eslint/no-var-requires
+
 const rspack = require('@rspack/core'); // eslint-disable-line @typescript-eslint/no-var-requires
 const dotenv = require('dotenv'); // eslint-disable-line @typescript-eslint/no-var-requires
 
@@ -17,6 +19,9 @@ module.exports = {
   },
   output: {
     filename: '[name].js',
+  },
+  resolve: {
+    tsConfigPath: path.resolve(__dirname, './tsconfig.json'),
   },
   plugins: [
     new rspack.HtmlRspackPlugin({

--- a/ui/src/components/DataTable.tsx
+++ b/ui/src/components/DataTable.tsx
@@ -21,9 +21,8 @@ import {
 
 import { useEffect, useState } from 'react';
 
-import type { RowError } from '../schema/utils.ts';
-
-import { validateData } from '../schema/utils.ts';
+import type { RowError } from 'src/schema/utils.ts';
+import { validateData } from 'src/schema/utils.ts';
 
 import TableCell from './TableCell.tsx';
 

--- a/ui/src/components/TableCell.tsx
+++ b/ui/src/components/TableCell.tsx
@@ -3,8 +3,8 @@ import type { Table } from '@tanstack/react-table';
 import type { ErrorObject } from 'ajv';
 import { useEffect, useState } from 'react';
 
-import type { RowError } from '../schema/utils.ts';
-import { constructErrorMessage } from '../schema/utils.ts';
+import type { RowError } from 'src/schema/utils.ts';
+import { constructErrorMessage } from 'src/schema/utils.ts';
 
 const isErrorCell = (rowError: RowError | undefined, header: string) => {
   if (!rowError || !rowError.errors || rowError.valid) {

--- a/ui/src/components/auth/AuthNavButton.tsx
+++ b/ui/src/components/auth/AuthNavButton.tsx
@@ -7,7 +7,7 @@ import { useLocation } from 'react-router-dom';
 
 import { useSpinDelay } from 'spin-delay';
 
-import { Link } from '../Link.tsx';
+import { Link } from 'src/components/Link.tsx';
 
 import { useSession } from './session.tsx';
 

--- a/ui/src/components/layout/Footer.tsx
+++ b/ui/src/components/layout/Footer.tsx
@@ -1,9 +1,9 @@
 import { Box, Text, SimpleGrid, Container, Spacer } from '@chakra-ui/react';
 import { Trans } from '@lingui/macro';
 
-import { Link } from '../Link.tsx';
+import { Link } from 'src/components/Link.tsx';
 
-// import CanadaWhiteFont from '../../assets/wmms-blk.svg'
+// import CanadaWhiteFont from 'src/assets/wmms-blk.svg'
 
 type CanadaWithFlagProps = {
   textColor?: 'black' | 'white';

--- a/ui/src/components/layout/Header.tsx
+++ b/ui/src/components/layout/Header.tsx
@@ -3,11 +3,12 @@ import { HStack, Box, Container } from '@chakra-ui/react';
 import { Trans } from '@lingui/macro';
 import { useLingui } from '@lingui/react';
 
-import CanadaLogoEn from '../../assets/sig-blk-en.svg';
-import CanadaLogoFr from '../../assets/sig-blk-fr.svg';
-import AuthNavButton from '../auth/AuthNavButton.tsx';
-import LanguageButton from '../LanguageButton.tsx';
-import { Link } from '../Link.tsx';
+import CanadaLogoEn from 'src/assets/sig-blk-en.svg';
+import CanadaLogoFr from 'src/assets/sig-blk-fr.svg';
+
+import AuthNavButton from 'src/components/auth/AuthNavButton.tsx';
+import LanguageButton from 'src/components/LanguageButton.tsx';
+import { Link } from 'src/components/Link.tsx';
 
 const NavButtonStyle = {
   h: '30px',

--- a/ui/src/pages/ExcelParser.tsx
+++ b/ui/src/pages/ExcelParser.tsx
@@ -3,8 +3,8 @@ import { Trans } from '@lingui/macro';
 import { useState } from 'react';
 import type { WorkBook } from 'xlsx';
 
-import ExcelFileOutput from '../components/ExcelFileOutput.tsx';
-import ExcelUploadForm from '../components/ExcelUploadForm.tsx';
+import ExcelFileOutput from 'src/components/ExcelFileOutput.tsx';
+import ExcelUploadForm from 'src/components/ExcelUploadForm.tsx';
 
 interface Sheet {
   sheetName: string;

--- a/ui/src/pages/NavPage.tsx
+++ b/ui/src/pages/NavPage.tsx
@@ -1,7 +1,7 @@
 import { Outlet } from 'react-router-dom';
 
-import Footer from '../components/layout/Footer.tsx';
-import Header from '../components/layout/Header.tsx';
+import Footer from 'src/components/layout/Footer.tsx';
+import Header from 'src/components/layout/Header.tsx';
 
 // This is the component that renders the header and footer for all pages
 

--- a/ui/src/pages/NavWrapper.tsx
+++ b/ui/src/pages/NavWrapper.tsx
@@ -1,7 +1,7 @@
 import { Outlet } from 'react-router-dom';
 
-import Footer from '../components/layout/Footer.tsx';
-import Header from '../components/layout/Header.tsx';
+import Footer from 'src/components/layout/Footer.tsx';
+import Header from 'src/components/layout/Header.tsx';
 
 // This is the component that renders the header and footer for all pages
 export default function NavWrapper() {

--- a/ui/src/pages/SignIn.tsx
+++ b/ui/src/pages/SignIn.tsx
@@ -4,8 +4,8 @@ import { Trans } from '@lingui/macro';
 
 import { useNavigate, useSearchParams } from 'react-router-dom';
 
-import { useSession } from '../components/auth/session.tsx';
-import SignInForm from '../components/auth/SignInForm.tsx';
+import { useSession } from 'src/components/auth/session.tsx';
+import SignInForm from 'src/components/auth/SignInForm.tsx';
 
 export default function SignIn() {
   const navigate = useNavigate();

--- a/ui/src/pages/TermsAndConditions.tsx
+++ b/ui/src/pages/TermsAndConditions.tsx
@@ -10,7 +10,7 @@ import {
 
 import { Trans } from '@lingui/macro';
 
-import { Link } from '../components/Link.tsx';
+import { Link } from 'src/components/Link.tsx';
 
 export default function TermsAndConditions() {
   function NoticeOfAgreement() {

--- a/ui/tsconfig.json
+++ b/ui/tsconfig.json
@@ -14,7 +14,9 @@
     "strict": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
-    "noFallthroughCasesInSwitch": true
+    "noFallthroughCasesInSwitch": true,
+    "sourceMap": true,
+    "baseUrl": "./"
   },
-  "include": ["src"]
+  "include": ["./src/"]
 }


### PR DESCRIPTION
Helps keep module imports sane, especially when directory refactoring happens. Not specifically planning any big refactors soon, but I wanted to set this up before I forgot.

Will apply the same rules in the api dir after porting it to TS, which I plan to do soon.