### PR TITLE
In prod, run the api via tsx, rather than trying to compile for and run in node

### DIFF
--- a/api/Dockerfile.prod
+++ b/api/Dockerfile.prod
@@ -1,28 +1,11 @@
-# 1. Compile TS
-FROM node:lts-alpine3.19 AS build
-
-ENV NODE_ENV development
-
-WORKDIR /app
-
-COPY package*.json ./
-
-RUN npm ci
-
-COPY . /app
-RUN npm run build
-
-# 2. Run server, with prod env (no dev dependencies installed, etc)
 FROM node:lts-alpine3.19
 
 ENV NODE_ENV production
 
 WORKDIR /app
 
-COPY package*.json ./
+COPY . .
 RUN npm ci
-
-COPY --from=build /app/dist ./dist
 
 USER node
 

--- a/api/cloudbuild.yaml
+++ b/api/cloudbuild.yaml
@@ -1,4 +1,13 @@
 steps:
+  - id: 'Check types'
+    name: 'node:lts-alpine3.19'
+    entrypoint: 'sh'
+    dir: api
+    args:
+      - '-c'
+      - |
+        npm ci && npm run typecheck
+
   - id: 'Run tests'
     name: 'gcr.io/cloud-builders/docker'
     script: |

--- a/api/package.json
+++ b/api/package.json
@@ -7,22 +7,21 @@
     "node": "^20"
   },
   "type": "module",
-  "main": "./dist/index.js",
+  "main": "./src/index.ts",
   "scripts": {
-    "build": "tsc",
-    "start": "node --experimental-vm-modules ./dist/index.js",
-    "dev": "tsx --watch --experimental-vm-modules ./src/index.ts",
-    "dev:debug": "tsx --inspect-brk --watch --experimental-vm-modules ./src/index.ts",
+    "typecheck": "tsc --noEmit",
+    "start": "tsx ./src/index.ts",
+    "dev": "tsx --watch ./src/index.ts",
+    "dev:debug": "tsx --inspect-brk --watch ./src/index.ts",
     "dev:docker": "npm run dev",
-    "dev:docker-debug": "tsx --inspect-brk='0.0.0.0:9229' --watch --experimental-vm-modules ./src/index.ts",
+    "dev:docker-debug": "tsx --inspect-brk='0.0.0.0:9229' --watch ./src/index.ts",
     "test": "docker compose -f ./docker-compose.dev-test.yaml up --exit-code-from api-test",
     "pretest": "npm run test:down",
     "jest:docker": "node --experimental-vm-modules node_modules/.bin/jest --coverage --coverageReporters text",
     "jest:docker-debug": "node --experimental-vm-modules --inspect-brk='0.0.0.0:9229' node_modules/.bin/jest --runInBand --no-cache",
     "test:debug": "DOCKER_API_COMMAND=docker-debug docker compose -f ./docker-compose.dev-test.yaml up --exit-code-from api-test",
     "pretest:debug": "npm run test:down",
-    "test:down": "docker compose -f ./docker-compose.dev-test.yaml down",
-    "typecheck": "tsc --noEmit"
+    "test:down": "docker compose -f ./docker-compose.dev-test.yaml down"
   },
   "dependencies": {
     "@escape.tech/graphql-armor-max-aliases": "^1.6.1",


### PR DESCRIPTION
The TS compilation step in the previous `api/Dockerfile.prod` file was failing, the `api/tsconfig.json` was not properly configured for it (set `noEmit: true` for one thing :facepalm: haha). On further reading, I decided it wasn't worth the headache and pain points of either a) additional dependencies (pick your bundler) and configuration management to properly build our current source for a plain node run time, or b) writing source with idiosyncratic patterns (maybe require statments, probably lying to source and using `.js` in module paths even when actually targeting `.ts` modules...) and diverging from the patterns used on the `/ui` side.

The `tsx` maintainers have left the question of whether it's fit for production [as an exercise for the class,](https://tsx.is/faq#can-should-it-be-used-in-production) haha. Just relying on `tsx` is potentially riskier than configuring and using our own compilation + bundling set up for prod, but on the other hand that's more dependencies and configuration for us to own. At least this way the dev and prod run times are aligned, so we should notice something breaking right away and only have to maintain one configuration.

Could consider bun as the api run time, though I wouldn't expect it to be a total drop in against the current `api/tsconfig.json` either.