### PR TITLE
feat: allow ingress to api authz policy

### DIFF
--- a/kubernetes/apps/gke/api/authzpol.yaml
+++ b/kubernetes/apps/gke/api/authzpol.yaml
@@ -17,3 +17,20 @@ spec:
   - to:
     - operation:
         ports: ["27017"]
+---
+# allow ingress to api
+apiVersion: security.istio.io/v1beta1
+kind: AuthorizationPolicy
+metadata:
+ name: allow-ingress-to-api
+spec:
+ selector:
+   matchLabels:
+     app: api
+ action: ALLOW
+ rules: 
+  - from:
+    - source:
+        # <trust-domain>/ns/<namespace>/sa/<service-account-name>
+        principals: 
+          - "pdcp-cloud-005-safeinputs.svc.id.goog/ns/istio-ingress/sa/istio-ingressgateway"


### PR DESCRIPTION
Allow ingress from ingressgateway pod to api.