### PR TITLE
API error handling

### DIFF
--- a/api/src/__tests__/authz.test.ts
+++ b/api/src/__tests__/authz.test.ts
@@ -23,8 +23,8 @@ const throws_error_with_status_code = (
   } catch (error) {
     return (
       error instanceof Error &&
-      'statusCode' in error &&
-      error.statusCode === expected_status_code
+      'status' in error &&
+      error.status === expected_status_code
     );
   }
 };

--- a/api/src/__tests__/error_utils.test.ts
+++ b/api/src/__tests__/error_utils.test.ts
@@ -1,14 +1,14 @@
 import { AppError } from 'src/error_utils.ts';
 
 describe('AppError', () => {
-  it('constructs a new error with the provided message and the additional statusCode property', () => {
+  it('constructs a new error with the provided message and the additional status property', () => {
     const message = 'test message for testing the message';
-    const statusCode = 123;
+    const status = 123;
 
-    const appError = new AppError(statusCode, message);
+    const appError = new AppError(status, message);
 
     expect(appError).toBeInstanceOf(Error);
     expect(appError.message).toBe(message);
-    expect(appError.statusCode).toBe(statusCode);
+    expect(appError.status).toBe(status);
   });
 });

--- a/api/src/__tests__/error_utils.test.ts
+++ b/api/src/__tests__/error_utils.test.ts
@@ -1,4 +1,7 @@
-import { AppError } from 'src/error_utils.ts';
+import express from 'express';
+import request from 'supertest'; // eslint-disable-line node/no-unpublished-import
+
+import { AppError, errorHandler } from 'src/error_utils.ts';
 
 describe('AppError', () => {
   it('constructs a new error with the provided message and the additional status property', () => {
@@ -10,5 +13,69 @@ describe('AppError', () => {
     expect(appError).toBeInstanceOf(Error);
     expect(appError.message).toBe(message);
     expect(appError.status).toBe(status);
+  });
+});
+
+describe('errorHandler middlewear', () => {
+  it('handles errors passed to next() by express routes', async () => {
+    const app = express();
+
+    const status_code = 500;
+
+    app.get('/error-via-next', function (_req, _res, next) {
+      next(new AppError(status_code, 'error'));
+    });
+
+    const mockedErrorHandler = jest.fn(errorHandler);
+    app.use(mockedErrorHandler);
+
+    const response = await request(app)
+      .get('/error-via-next')
+      .set('Accept', 'application/json');
+
+    expect(mockedErrorHandler).toHaveBeenCalledTimes(1);
+    expect(response.status).toBe(status_code);
+  });
+
+  it('handles errors thrown by express routes', async () => {
+    const app = express();
+
+    const status_code = 500;
+
+    app.get('/error-via-next', function (_req, _res, _next) {
+      throw new AppError(status_code, 'error');
+    });
+
+    const mockedErrorHandler = jest.fn(errorHandler);
+    app.use(mockedErrorHandler);
+
+    const response = await request(app)
+      .get('/error-via-next')
+      .set('Accept', 'application/json');
+
+    expect(mockedErrorHandler).toHaveBeenCalled();
+    expect(response.status).toBe(status_code);
+  });
+
+  it('sets the response status based on the error, includes the error message in the response body', async () => {
+    const app = express();
+
+    const status_code = 418;
+    const error_message = "I'm a teapot";
+
+    app.get('/error', function (_req, _res, _next) {
+      throw new AppError(status_code, error_message);
+    });
+
+    const mockedErrorHandler = jest.fn(errorHandler);
+    app.use(mockedErrorHandler);
+
+    const response = await request(app)
+      .get('/error')
+      .set('Accept', 'application/json');
+
+    expect(mockedErrorHandler).toHaveBeenCalled();
+    expect(response.status).toBe(status_code);
+    expect(response.body.error).toBe(error_message);
   });
 });

--- a/api/src/create_app.ts
+++ b/api/src/create_app.ts
@@ -13,6 +13,7 @@ import passport from 'passport';
 import { configure_passport_js, get_auth_router } from './authn.ts';
 import { connect_db, get_db_client } from './db.ts';
 import { get_env } from './env.ts';
+import { errorHandler } from './error_utils.ts';
 
 export const create_app = async ({
   schema,
@@ -108,6 +109,8 @@ export const create_app = async ({
   });
 
   app.use(yoga.graphqlEndpoint, yoga);
+
+  app.use(errorHandler);
 
   return app;
 };

--- a/api/src/env.ts
+++ b/api/src/env.ts
@@ -98,6 +98,7 @@ export const get_env = () => {
     AUTHZ_SUPER_ADMINS: emailList(),
 
     DEV_IS_LOCAL_ENV: boolFalseIfProd({ default: false }),
+    DEV_IS_TEST_ENV: boolFalseIfProd({ default: false }),
     DEV_FORCE_ENABLE_GCNOTIFY: boolFalseIfProd({ default: false }),
     DEV_FORCE_DISABLE_CSRF_PROTECTION: boolFalseIfProd({ default: false }),
   });

--- a/api/src/error_utils.ts
+++ b/api/src/error_utils.ts
@@ -1,3 +1,5 @@
+import type { Request, Response, NextFunction } from 'express';
+
 export type AppErrorInstance = Error & { status: number };
 
 interface AppErrorConstructor {
@@ -8,7 +10,22 @@ interface AppErrorConstructor {
 export const AppError = function (status: number, message: string) {
   const error = new Error(message) as AppErrorInstance;
 
+  // standard in express.js to add an HTTP status code on errors, as `status`, to be used by error handling middleware/error responses
+  // both when throwing errors and when passing them to an express `next` call
   error.status = status;
 
   return error;
 } as AppErrorConstructor;
+
+export const errorHandler = (
+  err: Error | AppErrorInstance,
+  _req: Request,
+  res: Response,
+  _next: NextFunction,
+) => {
+  console.error(err.stack); // TODO: a good structured logging library and logging utils are a TODO
+
+  const status_code = 'status' in err ? err.status : 500;
+
+  res.status(status_code).json({ error: err.message });
+};

--- a/api/src/error_utils.ts
+++ b/api/src/error_utils.ts
@@ -1,14 +1,14 @@
-export type AppErrorInstance = Error & { statusCode: number };
+export type AppErrorInstance = Error & { status: number };
 
 interface AppErrorConstructor {
-  (statusCode: number, message: string): AppErrorInstance;
-  new (statusCode: number, message: string): AppErrorInstance;
+  (status: number, message: string): AppErrorInstance;
+  new (status: number, message: string): AppErrorInstance;
 }
 
-export const AppError = function (statusCode: number, message: string) {
+export const AppError = function (status: number, message: string) {
   const error = new Error(message) as AppErrorInstance;
 
-  error.statusCode = statusCode;
+  error.status = status;
 
   return error;
 } as AppErrorConstructor;

--- a/api/src/error_utils.ts
+++ b/api/src/error_utils.ts
@@ -1,5 +1,7 @@
 import type { Request, Response, NextFunction } from 'express';
 
+import { get_env } from './env.ts';
+
 export type AppErrorInstance = Error & { status: number };
 
 interface AppErrorConstructor {
@@ -23,7 +25,13 @@ export const errorHandler = (
   res: Response,
   _next: NextFunction,
 ) => {
-  console.error(err.stack); // TODO: a good structured logging library and logging utils are a TODO
+  const { DEV_IS_TEST_ENV } = get_env();
+
+  if (!DEV_IS_TEST_ENV) {
+    // TODO: a good structured logging library and logging utils are a TODO
+    // console output should be silenced when running tests, for clean test reports
+    console.error(err.stack);
+  }
 
   const status_code = 'status' in err ? err.status : 500;
 


### PR DESCRIPTION
Replace the default express.js error handling behaviour of returning an HTML response containing the error message with a custom handler that returns the error message in JSON for the client side app to catch and choose how to display.

Will be opening follow up issues for related next steps.