### PR TITLE
feat: ignore pinning for flux managed images

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -22,4 +22,15 @@
       "(^|/)kubernetes/.+\\.ya?ml(?:\\.j2)?$"
     ]
   },
+  "packageRules": [
+    {
+
+      "description": "Ignore pinning for images managed by Flux",
+      "matchFileNames": [
+        "./kubernetes/apps/base/api/deployment.yaml",
+        "./kubernetes/apps/base/ui/deployment.yaml"
+      ],
+      "pinDigest": false
+    },
+  ]
 }

--- a/renovate.json5
+++ b/renovate.json5
@@ -31,9 +31,7 @@
         "./kubernetes/apps/base/ui/deployment.yaml"
       ],
       "matchUpdateTypes": ["pinDigest"],
-      "pinDigest": {
-        "enabled": false
-      } 
+      "enabled": false
     },
   ]
 }

--- a/renovate.json5
+++ b/renovate.json5
@@ -30,7 +30,7 @@
         "./kubernetes/apps/base/api/deployment.yaml",
         "./kubernetes/apps/base/ui/deployment.yaml"
       ],
-      matchUpdateTypes: ["pinDigest"],
+      "matchUpdateTypes": ["pinDigest"],
       "pinDigest": {
         "enabled": false
       } 

--- a/renovate.json5
+++ b/renovate.json5
@@ -26,9 +26,9 @@
     {
 
       "description": "Ignore pinning for images managed by Flux",
-      "matchFileNames": [
-        "./kubernetes/apps/base/api/deployment.yaml",
-        "./kubernetes/apps/base/ui/deployment.yaml"
+      "matchPackageNames": [
+        "northamerica-northeast1-docker.pkg.dev/pdcp-cloud-005-safeinputs/safeinputs/api",
+        "northamerica-northeast1-docker.pkg.dev/pdcp-cloud-005-safeinputs/safeinputs/ui",
       ],
       "matchUpdateTypes": ["pinDigest"],
       "pinDigest": {

--- a/renovate.json5
+++ b/renovate.json5
@@ -31,7 +31,9 @@
         "./kubernetes/apps/base/ui/deployment.yaml"
       ],
       "matchUpdateTypes": ["pinDigest"],
-      "enabled": false
+      "pinDigest": {
+        "enabled": false
+      } 
     },
   ]
 }

--- a/renovate.json5
+++ b/renovate.json5
@@ -30,7 +30,10 @@
         "./kubernetes/apps/base/api/deployment.yaml",
         "./kubernetes/apps/base/ui/deployment.yaml"
       ],
-      "pinDigest": false
+      matchUpdateTypes: ["pinDigest"],
+      "pinDigest": {
+        "enabled": false
+      } 
     },
   ]
 }


### PR DESCRIPTION
As discussed in https://github.com/PHACDataHub/safe-inputs/pull/187#pullrequestreview-2148292813.