### PR TITLE
Fix Link ref passing

### DIFF
--- a/ui/src/components/Link.tsx
+++ b/ui/src/components/Link.tsx
@@ -1,5 +1,5 @@
-import type { LinkProps as ChakraLinkProps } from '@chakra-ui/react';
-import { Link as ChakraLink } from '@chakra-ui/react';
+import type { LinkProps as ChakraLinkProps, As } from '@chakra-ui/react';
+import { Link as ChakraLink, forwardRef } from '@chakra-ui/react';
 
 import type { LinkProps as ReactRouterLinkProps } from 'react-router-dom';
 import { Link as ReactRouterLink } from 'react-router-dom';
@@ -13,17 +13,16 @@ type InAppLinkProps = Omit<
 
 type ExternalLinkProps = Omit<
   SetRequired<ChakraLinkProps, 'href'>,
-  'isExternal'
+  'isExternal' | 'to'
 >;
 
-function Link(props: ExternalLinkProps): JSX.Element;
-function Link(props: InAppLinkProps): JSX.Element;
-function Link(props: ExternalLinkProps | InAppLinkProps): JSX.Element {
-  return 'href' in props ? (
-    <ChakraLink {...props} isExternal={true} />
+export const Link: {
+  (props: ExternalLinkProps): JSX.Element;
+  (props: InAppLinkProps): JSX.Element;
+} = forwardRef<InAppLinkProps | ExternalLinkProps, As>((props, ref) =>
+  'href' in props ? (
+    <ChakraLink {...props} ref={ref} isExternal={true} />
   ) : (
-    <ChakraLink {...props} as={ReactRouterLink} />
-  );
-}
-
-export { Link };
+    <ChakraLink {...props} ref={ref} as={ReactRouterLink} />
+  ),
+);


### PR DESCRIPTION
Addresses the following warning:
```
 Warning: Function components cannot be given refs. Attempts to access this ref will fail. Did you mean to use React.forwardRef()?

Check the render method of `Styled(button)`.
    at Link (http://localhost:8080/main.js:19362:19)
    at http://localhost:8080/main.js:4530:71
    at ChakraComponent (http://localhost:8080/main.js:119447:107)
    at http://localhost:8080/main.js:114247:87
    at AuthNavButton (http://localhost:8080/main.js:19444:96)
    ...
```

Also tightens up the function overload types slightly, the external link case shouldn't use the `to` prop.