### PR TITLE
Fix CSRF on GQL queries

### DIFF
--- a/api/src/create_app.ts
+++ b/api/src/create_app.ts
@@ -106,6 +106,13 @@ export const create_app = async ({
       maxDepthPlugin({ n: 6 }), // Number of depth allowed | Default: 6
     ],
     graphqlEndpoint: '/api/graphql',
+    graphiql: {
+      // GraphiQL must use GET requests or else it will be blocked by doubleCsrfProtection
+      // Note: yoga does not accept mutations in GET requests (good, we want CSRF protection on mutations,
+      // and will require auth too), so GraphiQL can't be used for testing mutations
+      method: 'GET',
+      useGETForQueries: true,
+    },
   });
 
   app.use(yoga.graphqlEndpoint, yoga);

--- a/api/src/create_app.ts
+++ b/api/src/create_app.ts
@@ -78,6 +78,7 @@ export const create_app = async ({
       sameSite: DEV_IS_LOCAL_ENV ? 'lax' : 'strict',
       secure: !DEV_IS_LOCAL_ENV,
     },
+    ignoredMethods: ['GET', 'HEAD', 'OPTIONS'], // these are the defaults, including for documentation purposes. CSRF protection is only applied to POST, PUT, etc.
   });
 
   // important: session middleware needs to come before the CSRF middleware is added!

--- a/ui/src/components/auth/auth_utils.ts
+++ b/ui/src/components/auth/auth_utils.ts
@@ -21,7 +21,12 @@ const auth_get = async (auth_base_url: string, path: string) => {
   return { response, data };
 };
 
-const get_csrf_token = async (auth_base_url: string) => {
+export const csrf_header = 'x-csrf-token';
+export const get_csrf_token = async (auth_base_url: string) => {
+  // TODO: could do with caching if every POST request needs to call it first,
+  // but that's tricky as it needs to either cache cross tabs (security risk to using local storage though)
+  // or invalidate if any other tab calls get_csrf_token/refreshes the csrf-token header.
+  // Maybe use some non-sensitive data in localstorage to track when an invalidation happens?
   const { data } = await auth_get(auth_base_url, 'csrf-token');
 
   if (typeof data?.csrfToken === 'string') {
@@ -57,7 +62,7 @@ const auth_post = async (
     method: 'post',
     headers: {
       'Content-Type': 'application/x-www-form-urlencoded',
-      'x-csrf-token': csrf_token,
+      [csrf_header]: csrf_token,
     },
     body: new URLSearchParams(
       _.omitBy(options, (value) => typeof value === 'undefined'),


### PR DESCRIPTION
Configure the Apollo client to get and include a CSRF token in all requests. Configure GraphiQL to use GET requests (which don't require CSRF) for queries. Note: mutations written in GraphiQL will still be blocked by CSRF/auth checks, but I think that's a feature not a bug.