### PR TITLE
feat: update mongo agent log file to stdout

### DIFF
--- a/kubernetes/apps/base/api/mongodb.yaml
+++ b/kubernetes/apps/base/api/mongodb.yaml
@@ -41,6 +41,8 @@ kind: MongoDBCommunity
 metadata:
   name: mongodb
 spec:
+  agent:
+    logFile: /dev/stdout
   type: ReplicaSet
   security:
     authentication:


### PR DESCRIPTION
Closes #240 

Relevant docs: https://github.com/mongodb/mongodb-kubernetes-operator/blob/master/docs/logging.md.

Assuming the kubernetes operator follows the official mongo conventions, the default log level should be set to `INFO`. [Here's](https://www.mongodb.com/docs/ops-manager/current/reference/mongodb-agent-settings/#mongodb-setting-logLevel) a list of valid values.