### PR TITLE
UI Jest/Lingui compatibility fix, and related test utilities

### DIFF
--- a/api/jest.config.cjs
+++ b/api/jest.config.cjs
@@ -5,10 +5,12 @@ const { compilerOptions } = require('./tsconfig.json');
 module.exports = {
   // api specific
   testEnvironment: 'node',
-  setupFilesAfterEnv: ['./src/setup_tests.ts'],
-
-  // common
   preset: 'ts-jest',
+  setupFilesAfterEnv: ['./src/setup_tests.ts'],
+  collectCoverageFrom: ['src/**/*.ts'],
+  coveragePathIgnorePatterns: ['.test.ts'],
+
+  // common with /ui jest config
   roots: ['<rootDir>'],
   modulePaths: [compilerOptions.baseUrl],
   moduleNameMapper: pathsToModuleNameMapper(compilerOptions.paths, {

--- a/ui/babel.config.cjs
+++ b/ui/babel.config.cjs
@@ -1,0 +1,9 @@
+module.exports = {
+  presets: [
+    '@babel/preset-env',
+    '@babel/preset-typescript',
+    // so that React doesn't need to be explicitly imported in every jsx file
+    ['@babel/preset-react', { runtime: 'automatic' }],
+  ],
+  plugins: ['macros'],
+};

--- a/ui/jest.config.cjs
+++ b/ui/jest.config.cjs
@@ -5,13 +5,27 @@ const { compilerOptions } = require('./tsconfig.json');
 module.exports = {
   // ui specific
   testEnvironment: 'jsdom',
+  transform: {
+    '\\.(ts|tsx)$': 'babel-jest',
+  },
+  collectCoverageFrom: ['src/**/*.ts', 'src/**/*.tsx'],
+  coveragePathIgnorePatterns: [
+    '.test.ts',
+    '.test.tsx',
+    'i18n/locales',
+    'test_utils',
+  ],
+  moduleNameMapper: {
+    '\\.(css|less|scss|sass)$': '<rootDir>/src/test_utils/mocks/styleMock.js',
+    '\\.svg$': '<rootDir>/src/test_utils/mocks/svgMock.js',
+    // next line is also common between /ui and /api
+    ...pathsToModuleNameMapper(compilerOptions.paths, {
+      prefix: '<rootDir>',
+    }),
+  },
 
-  // common
-  preset: 'ts-jest',
+  // common with /api jest config
   roots: ['<rootDir>'],
   modulePaths: [compilerOptions.baseUrl],
-  moduleNameMapper: pathsToModuleNameMapper(compilerOptions.paths, {
-    prefix: '<rootDir>',
-  }),
   verbose: true,
 };

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -56,7 +56,6 @@
         "jest-environment-jsdom": "29.7.0",
         "react-test-renderer": "18.3.1",
         "swc-loader": "0.2.6",
-        "ts-jest": "29.2.4",
         "type-fest": "4.24.0",
         "typescript": "5.5.4"
       }
@@ -657,6 +656,9 @@
       "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.25.0.tgz",
       "integrity": "sha512-CzdIU9jdP0dg7HdyB+bHvDJGagUv+qtzZt5rYCWwW6tITNqV9odjp6Qu41gkG0ca5UfdDUWrKkiAnHHdGRnOrA==",
       "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.25.2"
+      },
       "bin": {
         "parser": "bin/babel-parser.js"
       },
@@ -5894,6 +5896,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -5910,6 +5913,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -5926,6 +5930,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -5942,6 +5947,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -5958,6 +5964,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -5974,6 +5981,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -5990,6 +5998,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -6006,6 +6015,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -6022,6 +6032,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -6038,6 +6049,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [

--- a/ui/package.json
+++ b/ui/package.json
@@ -9,13 +9,9 @@
     "precompile": "npm run extract",
     "compile": "lingui compile --typescript",
     "dev": "rspack serve",
-    "test": "jest",
+    "test": "jest --coverage --coverageReporters text",
+    "test:debug": "node --inspect-brk='0.0.0.0:9229' node_modules/.bin/jest --runInBand --no-cache",
     "typecheck": "tsc --noEmit"
-  },
-  "babel": {
-    "plugins": [
-      "macros"
-    ]
   },
   "dependencies": {
     "@apollo/client": "^3.9.4",
@@ -65,7 +61,6 @@
     "jest-environment-jsdom": "29.7.0",
     "react-test-renderer": "18.3.1",
     "swc-loader": "0.2.6",
-    "ts-jest": "29.2.4",
     "type-fest": "4.24.0",
     "typescript": "5.5.4"
   }

--- a/ui/rspack.config.cjs
+++ b/ui/rspack.config.cjs
@@ -43,14 +43,6 @@ module.exports = {
         exclude: /node_modules/,
         use: {
           loader: 'babel-loader',
-          options: {
-            presets: [
-              '@babel/preset-typescript',
-              // To avoid importing React
-              ['@babel/preset-react', { runtime: 'automatic' }],
-            ],
-            plugins: ['macros'],
-          },
         },
       },
     ],

--- a/ui/src/components/LanguageButton.test.tsx
+++ b/ui/src/components/LanguageButton.test.tsx
@@ -1,0 +1,50 @@
+import '@testing-library/jest-dom';
+import { fireEvent, render, within } from '@testing-library/react';
+
+import { TestProviders, i18nInstance } from 'src/test_utils/TestProviders.tsx';
+
+import LanguageButton from './LanguageButton.tsx';
+
+describe('<LanguageButton />', () => {
+  it('Renders a button which displays the inverse of the active lang option', () => {
+    const { container: container_en } = render(
+      <TestProviders i18n_lang="en">
+        <LanguageButton />
+      </TestProviders>,
+    );
+
+    expect(i18nInstance.locale).toEqual('en');
+
+    const button_en = within(container_en).getByRole('button');
+    expect(button_en).toHaveTextContent(/fr/i);
+
+    const { container: container_fr } = render(
+      <TestProviders i18n_lang="fr">
+        <LanguageButton />
+      </TestProviders>,
+    );
+
+    expect(i18nInstance.locale).toEqual('fr');
+
+    const button_fr = within(container_fr).getByRole('button');
+    expect(button_fr).toHaveTextContent(/en/i);
+  });
+
+  it('On click, toggles the app language', () => {
+    const { container } = render(
+      <TestProviders i18n_lang="en">
+        <LanguageButton />
+      </TestProviders>,
+    );
+
+    expect(i18nInstance.locale).toEqual('en');
+
+    const button = within(container).getByRole('button');
+    expect(button).toHaveTextContent(/fr/i);
+
+    fireEvent.click(button);
+
+    expect(i18nInstance.locale).toEqual('fr');
+    expect(button).toHaveTextContent(/en/i);
+  });
+});

--- a/ui/src/test_utils/TestProviders.tsx
+++ b/ui/src/test_utils/TestProviders.tsx
@@ -1,0 +1,22 @@
+import { i18n } from '@lingui/core';
+import { I18nProvider } from '@lingui/react';
+
+import type { PropsWithChildren } from 'react';
+
+import { messages } from 'src/i18n/locales/en/messages.ts';
+import { messages as frMessages } from 'src/i18n/locales/fr/messages.ts';
+
+i18n.load({
+  en: messages,
+  fr: frMessages,
+});
+
+export const i18nInstance = i18n;
+export const TestProviders = ({
+  children,
+  i18n_lang = 'en',
+}: PropsWithChildren<{ i18n_lang?: 'en' | 'fr' }>) => {
+  i18n.activate(i18n_lang);
+
+  return <I18nProvider i18n={i18n}>{children}</I18nProvider>;
+};

--- a/ui/src/test_utils/mocks/styleMock.js
+++ b/ui/src/test_utils/mocks/styleMock.js
@@ -1,0 +1,1 @@
+module.exports = {};

--- a/ui/src/test_utils/mocks/svgMock.js
+++ b/ui/src/test_utils/mocks/svgMock.js
@@ -1,0 +1,1 @@
+module.exports = 'svg-mock';

--- a/ui/test/LanguageButton.test.tsx
+++ b/ui/test/LanguageButton.test.tsx
@@ -1,4 +1,0 @@
-// TO DO: Add test cases
-describe('<LanguageButton />', () => {
-  it('renders LanguageButton without errors', () => {});
-});


### PR DESCRIPTION
Lingui's `macro` babel plugin can't handle the output of TypeScript's JSX transpiler. Our babel configuration, previously inside of `rspack.config.cjs`, worked because [plugins are run before any presets](https://babeljs.io/docs/plugins#plugin-ordering). Our Jest configuration did not, because my choice to try using `ts-jest`, for consistency with the `/api` jest configuration, meant that TypeScript was being run first (because our babel configuration was embedded in our rspack config, it wasn't picking up our babel config at all either way).

Ultimately, the `/ui` jest doesn't need to be using `ts-jest`, and the jest environment is closer to the real runtime if it just uses babel, sharing the runtime configuration.

Aside from that and some related misc jest configuration tweaks, I moved the `/ui` tests in to the `src` directory to be collocated with their source modules, and added a `ui/src/test_utilities` directory containing a lingui provider for tests to use and some global mocks for svg and style modules (the mocks originally came from Niranjan in #359).