### PR TITLE
Split dev subdomain and move capacitor

### DIFF
--- a/kubernetes/clusters/gke/components.yaml
+++ b/kubernetes/clusters/gke/components.yaml
@@ -68,7 +68,14 @@ spec:
           path: /spec/dnsNames
           value:
             - "safeinputs.alpha.phac-aspc.gc.ca"
-            - "capacitor.safeinputs.alpha.phac-aspc.gc.ca"
       target:
         kind: Certificate
         name: mesh-gateway-cert
+    - patch: |-
+        - op: add
+          path: /spec/dnsNames
+          value:
+            - "*.dev.safeinputs.alpha.phac-aspc.gc.ca"
+      target:
+        kind: Certificate
+        name: dev-mesh-gateway-cert

--- a/kubernetes/components/configs/capacitor.yaml
+++ b/kubernetes/components/configs/capacitor.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: capacitor
 spec:
   hosts:
-    - 'capacitor.safeinputs.alpha.phac-aspc.gc.ca'
+    - 'capacitor.dev.safeinputs.alpha.phac-aspc.gc.ca'
   gateways:
     - istio-ingress/mesh-gateway
   http:

--- a/kubernetes/components/configs/certificate.yaml
+++ b/kubernetes/components/configs/certificate.yaml
@@ -4,6 +4,7 @@ metadata:
   name: mesh-gateway-cert
   namespace: istio-ingress
 spec:
+  # this will be patched within ../../clusters/gke/components.yaml
   dnsNames: []
   issuerRef:
     kind: ClusterIssuer
@@ -14,3 +15,21 @@ spec:
     encoding: PKCS8
     size: 4096
   secretName: tlskeys
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: dev-mesh-gateway-cert
+  namespace: istio-ingress
+spec:
+  # this will be patched within ../../clusters/gke/components.yaml
+  dnsNames: []
+  issuerRef:
+    kind: ClusterIssuer
+    name: issuer
+  privateKey:
+    algorithm: RSA
+    encoding: PKCS8
+    rotationPolicy: Always
+    size: 4096
+  secretName: dev-tlskeys

--- a/kubernetes/components/configs/gateway.yaml
+++ b/kubernetes/components/configs/gateway.yaml
@@ -20,10 +20,22 @@ spec:
         name: https
         protocol: HTTPS
       hosts:
-        - '*'
+        - "safeinputs.alpha.phac-aspc.gc.ca"
       tls:
         mode: SIMPLE
         credentialName: tlskeys
+        privateKey: sds
+        serverCertificate: sds
+        minProtocolVersion: TLSV1_3
+    - port:
+        number: 443
+        name: https-dev
+        protocol: HTTPS
+      hosts:
+        - "*.dev.safeinputs.alpha.phac-aspc.gc.ca"
+      tls:
+        mode: SIMPLE
+        credentialName: dev-tlskeys
         privateKey: sds
         serverCertificate: sds
         minProtocolVersion: TLSV1_3

--- a/kubernetes/components/configs/gateway.yaml
+++ b/kubernetes/components/configs/gateway.yaml
@@ -20,7 +20,7 @@ spec:
         name: https
         protocol: HTTPS
       hosts:
-        - "safeinputs.alpha.phac-aspc.gc.ca"
+        - 'safeinputs.alpha.phac-aspc.gc.ca'
       tls:
         mode: SIMPLE
         credentialName: tlskeys
@@ -32,7 +32,7 @@ spec:
         name: https-dev
         protocol: HTTPS
       hosts:
-        - "*.dev.safeinputs.alpha.phac-aspc.gc.ca"
+        - '*.dev.safeinputs.alpha.phac-aspc.gc.ca'
       tls:
         mode: SIMPLE
         credentialName: dev-tlskeys


### PR DESCRIPTION
- Split dev and prod subdomain gateway and certificates
- Move capacitor to dev i.e, https://capacitor.dev.safeinputs.alpha.phac-aspc.gc.ca/

This would make it easier to address https://github.com/PHACDataHub/safe-inputs/issues/475 as we can add OAuth for all `*.dev` subdomains which could host internal dashboards.