### PR TITLE
Revert "chore: pin ghcr.io/gimlet-io/capacitor-manifests docker tag to 1e72940"

### DIFF
--- a/kubernetes/components/controllers/capacitor.yaml
+++ b/kubernetes/components/controllers/capacitor.yaml
@@ -14,7 +14,7 @@ spec:
   interval: 12h
   url: oci://ghcr.io/gimlet-io/capacitor-manifests
   ref:
-    tag: 'v0.4.2@sha256:1e72940be8383cd5054e3efcff8ec36f27e33959a4b940fc4b956c932083578b'
+    tag: 'v0.4.2'
   verify:
     provider: cosign
     matchOIDCIdentity:


### PR DESCRIPTION
Reverts PHACDataHub/safe-inputs#465

Adding digest on a tag causes errors during reconciliation as (_I'm guessing_) there's no such tag called `v0.4.2@sha256:1e72940be8383cd5054e3efcff8ec36f27e33959a4b940fc4b956c932083578b` in the [capacitor registry](https://github.com/gimlet-io/capacitor/pkgs/container/capacitor-manifests).
 
<details>

<summary>Error message</summary>

```sh
> kubectl events --for OCIRepository/capacitor -n capacitor
LAST SEEN            TYPE      REASON                  OBJECT                    MESSAGE
24s (x30 over 18h)   Warning   OCIArtifactPullFailed   OCIRepository/capacitor   failed to determine artifact digest: GET https://github.com/-/v2/packages/container/package/gimlet-io%!F(MISSING)capacitor-manifests%!F(MISSING)manifests%!F(MISSING)v0.4.2: unexpected status code 404 Not Found: Not Found
```

</details>

This wasn't flagged earlier because I missed adding capacitor to `kustomization.yaml`, but added it later as part of #499.

Reverting this for now to fix the reconciliations. I'll submit a PR later to configure renovate accordingly.