### PR TITLE
feat: ignore pinning for capacitor OCI repository

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -29,11 +29,9 @@
       },
     },
     {
-      "description": 'Ignore pinning for capacitor OCI repository',
-      "matchPackageNames": [
-        'ghcr.io/gimlet-io/capacitor-manifests',
-      ],
-      "pinDigests": false
+      description: 'Ignore pinning for capacitor OCI repository',
+      matchPackageNames: ['ghcr.io/gimlet-io/capacitor-manifests'],
+      pinDigests: false,
     },
   ],
 }

--- a/renovate.json5
+++ b/renovate.json5
@@ -18,7 +18,7 @@
   },
   packageRules: [
     {
-      description: 'Ignore pinning for images managed by Flux',
+      description: 'Ignore pinning for images managed by Flux. See https://github.com/PHACDataHub/safe-inputs/pull/187#discussion_r1658905664',
       matchPackageNames: [
         'northamerica-northeast1-docker.pkg.dev/phx-01j1tbke0ax/phx-01j1tbke0ax-safeinputs/api',
         'northamerica-northeast1-docker.pkg.dev/phx-01j1tbke0ax/phx-01j1tbke0ax-safeinputs/ui',
@@ -29,7 +29,7 @@
       },
     },
     {
-      description: 'Ignore pinning for capacitor OCI repository tag',
+      description: 'Ignore pinning for capacitor OCI repository tag. See https://github.com/PHACDataHub/safe-inputs/pull/505#issue-2478144189',
       matchPackageNames: ['ghcr.io/gimlet-io/capacitor-manifests'],
       pinDigests: false,
     },

--- a/renovate.json5
+++ b/renovate.json5
@@ -28,5 +28,12 @@
         enabled: false,
       },
     },
+    {
+      "description": 'Ignore pinning for capacitor OCI repository',
+      "matchPackageNames": [
+        'ghcr.io/gimlet-io/capacitor-manifests',
+      ],
+      "pinDigests": false
+    },
   ],
 }

--- a/renovate.json5
+++ b/renovate.json5
@@ -29,7 +29,7 @@
       },
     },
     {
-      description: 'Ignore pinning for capacitor OCI repository',
+      description: 'Ignore pinning for capacitor OCI repository tag',
       matchPackageNames: ['ghcr.io/gimlet-io/capacitor-manifests'],
       pinDigests: false,
     },


### PR DESCRIPTION
Relates to https://github.com/PHACDataHub/safe-inputs/pull/505#issue-2478144189

In case anyone's wondering why, unlike [here](https://github.com/PHACDataHub/safe-inputs/blob/8207575174f87313cd4c212e5a7b76a9223e7b20/renovate.json5#L27-L29), I used `pinDigests` (plural) instead of `pinDigest` - Although setting `pinDigest` ignores any PR's related to digest updates, it doesn't really stop a digest from creeping in via a `patch` update type.