### PR TITLE
feat: add pod monitor for Flux pods

### DIFF
--- a/kubernetes/clusters/gke/flux-podmonitor.yaml
+++ b/kubernetes/clusters/gke/flux-podmonitor.yaml
@@ -1,0 +1,22 @@
+apiVersion: monitoring.googleapis.com/v1
+kind: PodMonitoring
+metadata:
+  name: flux-system
+  labels:
+    app.kubernetes.io/part-of: flux
+    app.kubernetes.io/component: monitoring
+  namespace: flux-system
+spec:
+  selector:
+    matchExpressions:
+      - key: app
+        operator: In
+        values:
+          - helm-controller
+          - source-controller
+          - kustomize-controller
+          - notification-controller
+          - image-automation-controller
+          - image-reflector-controller
+  endpoints:
+    - port: http-prom


### PR DESCRIPTION
Set up [managed prometheus metric collection](https://cloud.google.com/stackdriver/docs/managed-prometheus/setup-managed) for Flux pods.