### PR TITLE
Remove redundant mongodb dependency in api/package.json

### DIFF
--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -26,7 +26,6 @@
         "graphql-type-json": "^0.3.2",
         "graphql-yoga": "^5.6.0",
         "lodash": "^4.17.21",
-        "mongodb": "^6.6.2",
         "mongoose": "^8.4.0",
         "passport": "^0.7.0",
         "passport-magic-link": "^2.1.1",

--- a/api/package.json
+++ b/api/package.json
@@ -45,7 +45,6 @@
     "graphql-type-json": "^0.3.2",
     "graphql-yoga": "^5.6.0",
     "lodash": "^4.17.21",
-    "mongodb": "^6.6.2",
     "mongoose": "^8.4.0",
     "passport": "^0.7.0",
     "passport-magic-link": "^2.1.1",


### PR DESCRIPTION
Renovate's package-lock editing was creating inconsistencies between mongoose's specific mongodb version requirements and the redundant direct mongodb dependency declared in `api/package.json` This was the problem with #222.